### PR TITLE
Return correct payload to Slack

### DIFF
--- a/src/slack/slack-handler.service.ts
+++ b/src/slack/slack-handler.service.ts
@@ -87,11 +87,17 @@ export class SlackHandler {
   }
 
   async handleInteractivity(payload: IncomingSlackInteractivity) {
-    return Promise.all(
+    const response = await Promise.all(
       this._interactivityHandlers.map(
         async (handlerConfig) =>
           await this.handleSingleInteractivity(payload, handlerConfig),
       ),
     );
+
+    const filtered = response.filter((elements) => {
+      return elements != null && elements !== undefined && elements !== '';
+    });
+
+    return filtered.length == 1 ? filtered[0] : filtered;
   }
 }


### PR DESCRIPTION
Handling Interactivity payloads from view_submissions requires a payload to be returned to slack. The current code outputs the incorrect format.
```
@Controller()
@SlackInteractivityListener()
export class SlackHandlerController {
  @SlackInteractivityHandler(ACTION_ID.VIEW_SUBMISSION)
  viewSubmission(event: IncomingSlackInteractivity) {
    return { response_action: 'clear' };
  }
}
```
When you have multiple handlers defined, the response returned from POST to /slack/interactivity has a payload
```
[
  null,
  null,
  { response_action: 'clear' },
  null,
  null
]
```
with a null for each handler not matching on `ACTION_ID.VIEW_SUBMISSION`.

This change compacts the list of responses to strip out any NULLs, Undefined or empty strings, and then assuming only a single handler returned an actual payload, returns that to slack.