### PR TITLE
refactor: replace deprecated method

### DIFF
--- a/src/slack/handler.explorer.ts
+++ b/src/slack/handler.explorer.ts
@@ -44,38 +44,34 @@ export class SlackHandlerExplorer {
       eventHandlers: instanceWrappers
         .map(({ instance }) => {
           const instancePrototype = Object.getPrototypeOf(instance);
-          return this.metadataScanner.scanFromPrototype(
-            instance,
-            instancePrototype,
-            (method) =>
-              this.exploreEventHandler(instance, instancePrototype, method),
-          );
+          return this.metadataScanner
+            .getAllMethodNames(instancePrototype)
+            .map((method) => {
+              return this.exploreEventHandler(instancePrototype, method);
+            });
         })
-        .reduce((prev, curr) => {
-          return prev.concat(curr);
+        .reduce((previous, current) => {
+          return previous.concat(current);
         }),
       interactivityHandlers: instanceWrappers
         .map(({ instance }) => {
           const instancePrototype = Object.getPrototypeOf(instance);
-          return this.metadataScanner.scanFromPrototype(
-            instance,
-            instancePrototype,
-            (method) =>
-              this.exploreInteractivityHandler(
-                instance,
+          return this.metadataScanner
+            .getAllMethodNames(instancePrototype)
+            .map((method) => {
+              return this.exploreInteractivityHandler(
                 instancePrototype,
                 method,
-              ),
-          );
+              );
+            });
         })
-        .reduce((prev, curr) => {
-          return prev.concat(curr);
+        .reduce((previous, current) => {
+          return previous.concat(current);
         }),
     };
   }
 
   public exploreEventHandler(
-    instance: object,
     instancePrototype: Controller,
     methodKey: string,
   ): SlackEventHandlerConfig | null {
@@ -88,7 +84,6 @@ export class SlackHandlerExplorer {
   }
 
   public exploreInteractivityHandler(
-    instance: object,
     instancePrototype: Controller,
     methodKey: string,
   ): SlackInteractivityHandlerConfig | null {


### PR DESCRIPTION
Replace deprecated method scanFromPrototype to getAllMethodNames
and Remove unnecessary parameter.